### PR TITLE
Enables zombie villager curing discount

### DIFF
--- a/paper.yml
+++ b/paper.yml
@@ -150,7 +150,7 @@ world-settings:
     mob-spawner-tick-rate: 2
     all-chunks-are-slime-chunks: false
     game-mechanics:
-      fix-curing-zombie-villager-discount-exploit: true
+      fix-curing-zombie-villager-discount-exploit: false
       nerf-pigmen-from-nether-portals: false
       disable-relative-projectile-velocity: false
       disable-pillager-patrols: true


### PR DESCRIPTION
This is a vanilla mechanic that is "fixed" by paper as a default. Following the logic of previous commits (which enable other vanilla mechanics like bedrock breaking), I presume we would want this mechanic enabled.