### PR TITLE
Update paper.yml

### DIFF
--- a/paper.yml
+++ b/paper.yml
@@ -152,7 +152,7 @@ world-settings:
     all-chunks-are-slime-chunks: false
     game-mechanics:
       disable-mob-spawner-spawn-egg-transformation: false
-      fix-curing-zombie-villager-discount-exploit: true
+      fix-curing-zombie-villager-discount-exploit: false
       nerf-pigmen-from-nether-portals: false
       disable-relative-projectile-velocity: false
       disable-pillager-patrols: true


### PR DESCRIPTION
Fixes villager curing. Was switched to patch in 1.16.4 on accident along with perm block breaking.